### PR TITLE
Remove duplicate lyric event addition

### DIFF
--- a/app/src/main/java/com/midisheetmusic/MidiTrack.java
+++ b/app/src/main/java/com/midisheetmusic/MidiTrack.java
@@ -66,10 +66,6 @@ public class MidiTrack {
             }
             else if (mevent.Metaevent == MidiFile.MetaEventLyric) {
                 AddLyric(mevent);
-                if (lyrics == null) {
-                    lyrics = new ArrayList<MidiEvent>();
-                }
-                lyrics.add(mevent);
             }
         }
         if (notes.size() > 0 && notes.get(0).getChannel() == 9)  {


### PR DESCRIPTION
The deleted code is the same as [addLyric()](https://github.com/ditek/MidiSheetMusic-Android/blob/7f69db039e1f9f088250886ea27d3c0aea563ae0/app/src/main/java/com/midisheetmusic/MidiTrack.java#L68), this code seems to be executed twice.